### PR TITLE
Corretto bug per la selezione del colore nei layer splitted.

### DIFF
--- a/public/services/plugins/dxfexport/dxfFactory.php
+++ b/public/services/plugins/dxfexport/dxfFactory.php
@@ -806,7 +806,7 @@ class dxfFactory{
 					}
 				}
 				//sezione simboli associati alle linee
-				if(!in_array($dLayer->{'layerName'}, $this->excludeGeometryLayers)){
+				//if(!in_array($dLayer->{'layerName'}, $this->excludeGeometryLayers)){
 					if(!is_null($symbolName)){
 						//$symbolName = "FGN_DIREZIONE_1";
 						$symbolCoords = $this->getPointCoordsDistance($coords, 10);
@@ -815,7 +815,7 @@ class dxfFactory{
 							$this->addInsert($dLayer->{'layerName'}, $symbolCoord[0], $symbolCoord[1], 0, $symbolName, $symbolCoord[2], $color, 1);
 						}
 					}
-				}
+				//}
 			break;
 			case "polygon":
 			case "multipolygon":

--- a/public/services/plugins/dxfexport/dxfFeatureExport.php
+++ b/public/services/plugins/dxfexport/dxfFeatureExport.php
@@ -294,8 +294,20 @@ class dxfFeatureExport {
 					foreach($styles as $style){
 						$clonedLayer = unserialize(serialize($layer));
 						$clonedLayer->{"layerName"} = $clonedLayer->{"layerName"}."_".$style->{"className"};
-						//var_dump($style);
 						$clonedLayer->{"styles"} = [$style];
+						//aggiornamento dei colori altrimenti prendono il colore del primo stile principale
+						if($style->{"outlinecolor"} != NULL){
+							$thisColor = explode(" ",$style->{"outlinecolor"});;
+							$clonedLayer->{"color"} = $this->getDecimalColor($thisColor[0], $thisColor[1], $thisColor[2]);
+						}else if($style->{"color"} != NULL){
+							$thisColor = explode(" ", $style->{"color"});;
+							$clonedLayer->{"color"} = $this->getDecimalColor($thisColor[0], $thisColor[1], $thisColor[2]);
+						}
+						else if($style->{"label_color"} != NULL){
+							//poi al colore della label
+							$thisColor = explode(" ", $style->{"label_color"});;
+							$clonedLayer->{"color"} = $this->getDecimalColor($thisColor[0], $thisColor[1], $thisColor[2]);
+						}
 						$clonedLayer->{"splitted"} = True;
 						array_push($layers, $clonedLayer);
 					}


### PR DESCRIPTION
Corretto bug per la selezione del colore nei layer splitted. Abilitato il disegno dei simboli nel caso di linee con simboli, anche se il layer è nell'array dxfExcludeGeometryLayers